### PR TITLE
[ROB-801] Add sshpass pkg to ansible install

### DIFF
--- a/tasks/ansible.yml
+++ b/tasks/ansible.yml
@@ -38,3 +38,10 @@
     pkg: nano
     state: latest
   become: true
+
+# enable server to be used as relay point for other IPs
+- name: Install sshpass
+  ansible.builtin.apt:
+    pkg: sshpass
+    state: latest
+  become: true


### PR DESCRIPTION
sshpass will allow easier relay between nodes (without manually managing ssh key for every devices). The main first target will probably be to use the camserver as a relay point to access devices behind its tailscale vpn. 